### PR TITLE
Support automatic release on py pi

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [windows-latest, macos-latest] # ubuntu-latest is failing anyway
+        platform: [windows-latest, ubuntu-latest, macos-latest] # ubuntu-latest is failing anyway
         python-version: ['3.8', '3.9', '3.10']
 
     steps:
@@ -47,7 +47,7 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
 
       - name: Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
 
   deploy:
     # this will run when you have tagged a commit, starting with "v*"

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools pytest-cov
+          pip install .
 
       # this runs the platform-specific tests
       - name: Run tests

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install setuptools tox tox-gh-actions pytest-qt
+          python -m pip install setuptools pytest-cov
 
       # this runs the platform-specific tests
       - name: Run tests

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -57,9 +57,9 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.ref, 'tags')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.x"
       - name: Install dependencies

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,0 +1,75 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+  pull_request:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: ${{ matrix.platform }} py${{ matrix.python-version }}
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        platform: [windows-latest, macos-latest] # ubuntu-latest is failing anyway
+        python-version: ['3.8', '3.9', '3.10']
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # note: if you need dependencies from conda, considering using
+      # setup-miniconda: https://github.com/conda-incubator/setup-miniconda
+      # and
+      # tox-conda: https://github.com/tox-dev/tox-conda
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools tox tox-gh-actions pytest-qt
+
+      # this runs the platform-specific tests
+      - name: Run tests
+        shell: bash -l {0}
+        run: pytest -v --cov=./ --cov-report=xml
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
+      - name: Coverage
+        uses: codecov/codecov-action@v2
+
+  deploy:
+    # this will run when you have tagged a commit, starting with "v*"
+    # and requires that you have put your twine API key in your
+    # github secrets (see readme for details)
+    needs: [test]
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'tags')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -U setuptools setuptools_scm wheel twine build
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          git tag
+          python -m build .
+          twine upload dist/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include LICENSE
+include README.md
+
+include data/*
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/pyFM/tests/test_data.py
+++ b/pyFM/tests/test_data.py
@@ -1,0 +1,8 @@
+def test_loading_data():
+    from pyFM.mesh import TriMesh
+    mesh1 = TriMesh('data/cat-00.off', area_normalize=True, center=False)
+    mesh2 = TriMesh('data/lion-00.off', area_normalize=True, center=True)
+
+    assert mesh1 is not None
+    assert mesh2 is not None
+    

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ install_requires =
     scipy
     potpourri3d
     robust_laplacian
-    meshplot
 python_requires = >=3.7
 include_package_data = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     scipy
     potpourri3d
     robust_laplacian
-    meshplot
+    tqdm
 python_requires = >=3.7
 include_package_data = True
 


### PR DESCRIPTION
Fixes #6 

Hi @RobinMagnet ,

this PR adds some support to make pyFM available through PyPi (a few extra steps on your side would still be required, though).

- It adds automatic testing workflows: I created a folder `tests` in the codebase. The code in there does nothing else but loading the data in the plugin and checking that it's not `None`. One could add more functions in there that assert that all provided functionality is running as expected. Every function in the `test` directory that has the term `test` in its function definition will be automatically called whenever something is changed on the main branch. It's super handy to ensure that the code is doing what you expect it to do.

- I added a `Manifest.in` file - this makes sure that all the data in the package that's not Python files (i.e., everything in `data/`) is uploaded to PyPi later.
- At the bottom of the `test_and_deploy.yml` there's this bit:
```
          TWINE_USERNAME: __token__
          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
```
- It allows Github to automatically build and push the package to PyPi, which is super convenient. For Github to have access to PyPi, you'd have to go to `https://pypi.org/manage/account/` and create an API token called `PYPI_API_TOKEN` . Once you have that, paste it and go to the repository settings under `Settings > Secrets and variables > Actions ` and create a `New secret`. The secret needs to be called `PYPI_API_TOKEN` - in the field you paste the long sequence you copied on the Pypi page.

- Lastly, to trigger the release on Pypi, you'd have to create a release (right hand side of the repository page). The release number should be the same as what's written in the `setupf.cfg` (currently `0.1.0`).

If you need help with anything along the process, let me know. 

I hope I'm not irritating or anything with my contributions ^^"